### PR TITLE
docs: align CONTRIBUTING with canonical template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,42 @@
+# Contributing
+
+## Prerequisites
+
+To build and run this extension locally, you need:
+
+- [Go](https://go.dev/dl/) 1.26 or later
+- [GNU Make](https://www.gnu.org/software/make/)
+- [GoReleaser](https://goreleaser.com/) (used by `make build`)
+- [Docker](https://www.docker.com/) (required for `make container` and container-based tests)
+
+## Getting Started
+
+1. Clone the repository
+2. `$ make tidy`
+3. `$ make run`
+4. `$ open http://localhost:8080`
+
+## Tasks
+
+The `Makefile` in the project root contains commands to easily run common admin tasks. Run `make help` to list all available targets.
+
+| Command            | Meaning                                                                                                  |
+|--------------------|----------------------------------------------------------------------------------------------------------|
+| `$ make tidy`      | Format all code using `go fmt` and tidy the `go.mod` file.                                               |
+| `$ make audit`     | Run `go vet`, `staticcheck`, execute all tests and verify required modules.                              |
+| `$ make build`     | Build a binary for the extension. Creates a file called `extension` in the repository root directory.    |
+| `$ make run`       | Build and then run the created binary.                                                                   |
+| `$ make container` | Build the container image (`extension-auto-registration-kubernetes:latest`) using Docker buildx.         |
+
+## Releasing the Code/Docker Image
+
+To make a new release, do the following:
+
+ 1. Update the `CHANGELOG.md`
+ 2. Commit and push the changelog changes.
+ 3. Set the tag `git tag -a vX.X.X -m vX.X.X`
+ 4. Push the tag.
+
 ## Contributor License Agreement (CLA)
 
 In order to accept your pull request, we need you to submit a CLA. You only need to do this once. If you are submitting a pull request for the first time, just submit a Pull Request and our CLA Bot will give you instructions on how to sign the CLA before merging your Pull Request.


### PR DESCRIPTION
## Summary

Align CONTRIBUTING.md with the canonical template used across Steadybit extension repositories.

- Add an explicit **Prerequisites** section listing required build tools and minimum versions (Go, Make, GoReleaser, Docker).
- Add a **Getting Started** quick-start and a **Tasks** table referencing the actual Makefile targets (`tidy`, `audit`, `build`, `run`, `container`).
- Document the release workflow and keep the standard CLA section.

This repo has no `charts/` directory, so the Helm release section from the standard template was intentionally omitted.