### PR TITLE
docs: remove stray build: bullet from latest CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v1.0.6
 
 - build(deps): bump github.com/steadybit/extension-kit
-- build: rename workflow_dispatch input labels for the GH UI
 
 ## v1.0.5
 


### PR DESCRIPTION
The auto-patch-release workflow added `- build: rename workflow_dispatch input labels for the GH UI` to the latest CHANGELOG entry. That bullet is a CI label rename with no runtime impact and shouldn't be user-facing.

A companion extension-kit PR adds `^build: ` to the default ignore regex so future runs skip such commits.