### PR TITLE
feat: register service cluster IPs as restricted IPs

### DIFF
--- a/autoregistration/autoregistration.go
+++ b/autoregistration/autoregistration.go
@@ -3,7 +3,9 @@ package autoregistration
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -167,6 +169,7 @@ func (r *AutoRegistration) toExtensionConfigs(pod *corev1.Pod) []ExtensionConfig
 						restrictedIps = append(restrictedIps, ingress.IP)
 					}
 				}
+				restrictedIps = append(restrictedIps, clusterIPsOfService(service)...)
 				if pod.Status.PodIP != "" {
 					restrictedIps = append(restrictedIps, pod.Status.PodIP)
 				}
@@ -186,6 +189,20 @@ func (r *AutoRegistration) toExtensionConfigs(pod *corev1.Pod) []ExtensionConfig
 		}
 	}
 	return result
+}
+
+// clusterIPsOfService returns the stable cluster IPs of the service. The agent uses them - besides the pod IPs - to exclude the
+// agent-to-extension communication from network attacks and as DNS-independent fallback addresses.
+func clusterIPsOfService(service *corev1.Service) []string {
+	candidates := append([]string{service.Spec.ClusterIP}, service.Spec.ClusterIPs...)
+	clusterIPs := make([]string, 0, len(candidates))
+	for _, ip := range candidates {
+		// "None" marks a headless service without a cluster IP
+		if ip != "" && !strings.EqualFold(ip, "None") && !slices.Contains(clusterIPs, ip) {
+			clusterIPs = append(clusterIPs, ip)
+		}
+	}
+	return clusterIPs
 }
 
 func (r *AutoRegistration) getExtensionAnnotations(annotations map[string]string) []ExtensionAnnotation {

--- a/autoregistration/autoregistration_test.go
+++ b/autoregistration/autoregistration_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package autoregistration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestClusterIPsOfService(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     corev1.ServiceSpec
+		expected []string
+	}{
+		{
+			name:     "single cluster IP",
+			spec:     corev1.ServiceSpec{ClusterIP: "172.20.14.11"},
+			expected: []string{"172.20.14.11"},
+		},
+		{
+			name:     "dual-stack cluster IPs without duplicates",
+			spec:     corev1.ServiceSpec{ClusterIP: "172.20.14.11", ClusterIPs: []string{"172.20.14.11", "fd00::42"}},
+			expected: []string{"172.20.14.11", "fd00::42"},
+		},
+		{
+			name:     "headless service",
+			spec:     corev1.ServiceSpec{ClusterIP: "None", ClusterIPs: []string{"None"}},
+			expected: []string{},
+		},
+		{
+			name:     "no cluster IP",
+			spec:     corev1.ServiceSpec{},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, clusterIPsOfService(&corev1.Service{Spec: tt.spec}))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Businessmap card 13020: for service-based extension registrations, `restrictedIps` contained only the pod IPs and load balancer ingress IPs. The service's stable **ClusterIP** was missing — the agent only picked it up by resolving the service DNS name at attack-prepare time. That resolution fails when DNS is already unavailable (e.g. a second attack prepared while a block-traffic/block-DNS attack is running), silently dropping the ClusterIP from the attack exclude list — the very entry that keeps agent→extension traffic alive.

## Change

Service-based registrations now include the service's cluster IPs (incl. dual-stack `spec.clusterIPs`) in `restrictedIps`. Headless services (`ClusterIP: None`) are unaffected. The ClusterIP is the one address that stays valid across pod restarts and needs no DNS or control-plane round-trip (kube-proxy DNAT is node-local), so both consumers on the agent side become DNS-independent:

- the network attack exclude list (agent → extension traffic protection)
- the agent's new DNS-failure fallback resolver (companion PR: steadybit/agent#508)

## Testing

- table-driven unit test for `clusterIPsOfService` (single IP, dual-stack + dedup, headless, none)
- `go build` / `go vet` / full package tests green

fixes 13020

https://claude.ai/code/session_015UawpRgthPbQx1FYZXyNuD